### PR TITLE
Reauthentication 

### DIFF
--- a/config/config.php
+++ b/config/config.php
@@ -9,4 +9,10 @@ return [
         'disk' => 'public',
     ],
 
+    //Reauthentication
+    'reauthentication' => [
+        'prefix' => 'cortex.fort.reauthentication.',
+        'timeout' => 60
+    ]
+
 ];

--- a/config/config.php
+++ b/config/config.php
@@ -12,7 +12,7 @@ return [
     //Reauthentication
     'reauthentication' => [
         'prefix' => 'cortex.fort.reauthentication.',
-        'timeout' => 60
+        'timeout' => 3600
     ]
 
 ];

--- a/config/config.php
+++ b/config/config.php
@@ -11,7 +11,6 @@ return [
 
     //Reauthentication
     'reauthentication' => [
-        'prefix' => 'cortex.fort.reauthentication.',
         'timeout' => 3600
     ]
 

--- a/resources/lang/en/common.php
+++ b/resources/lang/en/common.php
@@ -91,6 +91,7 @@ return [
     'account_settings' => 'Account Settings',
     'account_password' => 'Account Password',
     'active_sessions' => 'Active Sessions',
+    'reauthentication' => 'Reauthentication',
 
     // Misc
     'no' => 'No',

--- a/resources/views/frontarea/common/reauthentication/password.blade.php
+++ b/resources/views/frontarea/common/reauthentication/password.blade.php
@@ -1,0 +1,48 @@
+{{-- Master Layout --}}
+@extends('cortex/foundation::frontarea.layouts.default')
+
+{{-- Page Title --}}
+@section('title')
+    {{ config('app.name') }} » {{ trans('cortex/fort::common.reauthentication') }}
+@endsection
+
+@section('body-attributes')class="auth-page"@endsection
+
+{{-- Main Content --}}
+@section('content')
+
+    <div class="container">
+
+        <div class="row">
+
+            <div class="col-md-4 col-md-offset-4">
+
+                <section class="auth-form">
+
+                    {{ Form::open(['url' => route('frontarea.reauthentication.password.process'), 'id' => 'frontarea-reauthentication-form', 'role' => 'auth']) }}
+
+                    <div class="centered"><strong>{{ trans('cortex/fort::common.reauthentication') }}</strong></div>
+
+
+                    <div class="form-group has-feedback{{ $errors->has('password') ? ' has-error' : '' }}">
+                        {{ Form::password('password', ['class' => 'form-control input-lg', 'placeholder' => trans('cortex/fort::common.password'), 'required' => 'required']) }}
+
+                        @if ($errors->has('password'))
+                            <span class="help-block">{{ $errors->first('password') }}</span>
+                        @endif
+                    </div>
+
+                    {{ Form::button('<i class="fa fa-sign-in"></i> '.trans('cortex/fort::common.login'), ['class' => 'btn btn-lg btn-primary btn-block', 'type' => 'submit']) }}
+
+
+                    {{ Form::close() }}
+
+                </section>
+
+            </div>
+
+        </div>
+
+    </div>
+
+@endsection

--- a/resources/views/frontarea/common/reauthentication/twofactor.blade.php
+++ b/resources/views/frontarea/common/reauthentication/twofactor.blade.php
@@ -1,0 +1,48 @@
+{{-- Master Layout --}}
+@extends('cortex/foundation::frontarea.layouts.default')
+
+{{-- Page Title --}}
+@section('title')
+    {{ config('app.name') }} » {{ trans('cortex/fort::common.reauthentication') }}
+@endsection
+
+@section('body-attributes')class="auth-page"@endsection
+
+{{-- Main Content --}}
+@section('content')
+
+    <div class="container">
+
+        <div class="row">
+
+            <div class="col-md-4 col-md-offset-4">
+
+                <section class="auth-form">
+
+                    {{ Form::open(['url' => route('frontarea.reauthentication.twofactor.process'), 'id' => 'frontarea-reauthentication-form', 'role' => 'auth']) }}
+
+                    <div class="centered"><strong>{{ trans('cortex/fort::common.reauthentication') }}</strong></div>
+
+
+                    <div class="form-group has-feedback{{ $errors->has('token') ? ' has-error' : '' }}">
+                        {{ Form::text('token', null, ['class' => 'form-control input-lg', 'placeholder' => trans('cortex/fort::common.authentication_code'), 'required' => 'required', 'autofocus' => 'autofocus']) }}
+
+                        @if ($errors->has('token'))
+                            <span class="help-block">{{ $errors->first('token') }}</span>
+                        @endif
+                    </div>
+
+                    {{ Form::button('<i class="fa fa-sign-in"></i> '.trans('cortex/fort::common.login'), ['class' => 'btn btn-lg btn-primary btn-block', 'type' => 'submit']) }}
+
+
+                    {{ Form::close() }}
+
+                </section>
+
+            </div>
+
+        </div>
+
+    </div>
+
+@endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -99,6 +99,15 @@ Route::domain(domain())->group(function () {
             // Register authenication routes
             authentication_routes();
 
+            //Reauthentication Routes
+            Route::name('reauthentication.')->prefix('reauthentication')->group(function () {
+                // Reauthentication Password Routes
+                Route::post('password')->name('password.process')->uses('ReauthenticationController@processPassword');
+
+                // Reauthentication Twofactor Routes
+                Route::post('twofactor')->name('twofactor.process')->uses('ReauthenticationController@processTwofactor');
+            });
+
         });
 
 

--- a/src/Http/Controllers/Frontarea/ReauthenticationController.php
+++ b/src/Http/Controllers/Frontarea/ReauthenticationController.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cortex\Fort\Http\Controllers\Frontarea;
+
+use Cortex\Fort\Traits\TwoFactorAuthenticatesUsers;
+use Illuminate\Support\Facades\Hash;
+use Illuminate\Http\Request;
+use Cortex\Foundation\Http\Controllers\AuthenticatedController;
+
+class ReauthenticationController extends AuthenticatedController
+{
+
+    use TwoFactorAuthenticatesUsers;
+
+    /**
+     * @param Request $request
+     *
+     * @return \Illuminate\Http\JsonResponse|\Illuminate\Http\RedirectResponse
+     */
+    public function processPassword( Request $request ) {
+
+        $session_name = session(config('cortex.fort.reauthentication.prefix').'.session_name');
+        $redirect_url = session(config('cortex.fort.reauthentication.prefix').'.intended');
+
+        if( Hash::check($request->input('password'), request()->user()->password) ) {
+            $this->setSession($session_name);
+
+            return intend([
+                'intended' => url($redirect_url)
+            ]);
+        } else {
+            return intend([
+                'intended' => url($redirect_url),
+                'withErrors' => ['password' => trans('cortex/fort::messages.auth.failed')
+                ]
+            ]);
+        }
+    }
+
+    /**
+     * @param Request $request
+     *
+     * @return \Illuminate\Http\JsonResponse|\Illuminate\Http\RedirectResponse
+     */
+    public function processTwofactor( Request $request ) {
+
+        $session_name = session(config('cortex.fort.reauthentication.prefix').'.session_name');
+        $redirect_url = session(config('cortex.fort.reauthentication.prefix').'.intended');
+
+        $guard = $this->getGuard();
+        $token = $request->input('token');
+        $user = $request->user($guard);
+
+        if( $this->attemptTwoFactor($user, $token) ) {
+            $this->setSession($session_name);
+
+            return intend([
+                'intended' => url($redirect_url)
+            ]);
+        } else {
+            return intend([
+                'intended' => url($redirect_url),
+                'withErrors' => ['token' => trans('cortex/fort::messages.verification.twofactor.invalid_token')],
+            ]);
+        }
+    }
+
+    /**
+     * @param $session_name
+     */
+    protected  function setSession($session_name) {
+        session()->put($session_name, time());
+        session()->forget(config('cortex.fort.reauthentication.prefix').'.session_name');
+        session()->forget(config('cortex.fort.reauthentication.prefix').'.intended');
+        session()->forget('rinvex.fort.twofactor.totp');
+    }
+
+}

--- a/src/Http/Controllers/Frontarea/ReauthenticationController.php
+++ b/src/Http/Controllers/Frontarea/ReauthenticationController.php
@@ -21,8 +21,8 @@ class ReauthenticationController extends AuthenticatedController
      */
     public function processPassword( Request $request ) {
 
-        $session_name = session(config('cortex.fort.reauthentication.prefix').'.session_name');
-        $redirect_url = session(config('cortex.fort.reauthentication.prefix').'.intended');
+        $session_name = session('cortex.fort.reauthentication.session_name');
+        $redirect_url = session('cortex.fort.reauthentication.intended');
 
         if( Hash::check($request->input('password'), request()->user()->password) ) {
             $this->setSession($session_name);
@@ -46,8 +46,8 @@ class ReauthenticationController extends AuthenticatedController
      */
     public function processTwofactor( Request $request ) {
 
-        $session_name = session(config('cortex.fort.reauthentication.prefix').'.session_name');
-        $redirect_url = session(config('cortex.fort.reauthentication.prefix').'.intended');
+        $session_name = session('cortex.fort.reauthentication.session_name');
+        $redirect_url = session('cortex.fort.reauthentication.intended');
 
         $guard = $this->getGuard();
         $token = $request->input('token');
@@ -72,8 +72,8 @@ class ReauthenticationController extends AuthenticatedController
      */
     protected  function setSession($session_name) {
         session()->put($session_name, time());
-        session()->forget(config('cortex.fort.reauthentication.prefix').'.session_name');
-        session()->forget(config('cortex.fort.reauthentication.prefix').'.intended');
+        session()->forget('cortex.fort.reauthentication.session_name');
+        session()->forget('cortex.fort.reauthentication.intended');
         session()->forget('rinvex.fort.twofactor.totp');
     }
 

--- a/src/Http/Controllers/Frontarea/ReauthenticationController.php
+++ b/src/Http/Controllers/Frontarea/ReauthenticationController.php
@@ -4,14 +4,13 @@ declare(strict_types=1);
 
 namespace Cortex\Fort\Http\Controllers\Frontarea;
 
-use Cortex\Fort\Traits\TwoFactorAuthenticatesUsers;
-use Illuminate\Support\Facades\Hash;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Hash;
+use Cortex\Fort\Traits\TwoFactorAuthenticatesUsers;
 use Cortex\Foundation\Http\Controllers\AuthenticatedController;
 
 class ReauthenticationController extends AuthenticatedController
 {
-
     use TwoFactorAuthenticatesUsers;
 
     /**
@@ -19,24 +18,25 @@ class ReauthenticationController extends AuthenticatedController
      *
      * @return \Illuminate\Http\JsonResponse|\Illuminate\Http\RedirectResponse
      */
-    public function processPassword( Request $request ) {
-
-        $session_name = session('cortex.fort.reauthentication.session_name');
+    public function processPassword(Request $request)
+    {
         $redirect_url = session('cortex.fort.reauthentication.intended');
+        $session_name = session('cortex.fort.reauthentication.session_name');
 
-        if( Hash::check($request->input('password'), request()->user()->password) ) {
+        if (Hash::check($request->input('password'), request()->user()->password)) {
             $this->setSession($session_name);
 
             return intend([
-                'intended' => url($redirect_url)
-            ]);
-        } else {
-            return intend([
                 'intended' => url($redirect_url),
-                'withErrors' => ['password' => trans('cortex/fort::messages.auth.failed')
-                ]
             ]);
         }
+
+        return intend([
+            'intended' => url($redirect_url),
+            'withErrors' => [
+                'password' => trans('cortex/fort::messages.auth.failed'),
+            ],
+        ]);
     }
 
     /**
@@ -44,37 +44,36 @@ class ReauthenticationController extends AuthenticatedController
      *
      * @return \Illuminate\Http\JsonResponse|\Illuminate\Http\RedirectResponse
      */
-    public function processTwofactor( Request $request ) {
-
-        $session_name = session('cortex.fort.reauthentication.session_name');
+    public function processTwofactor(Request $request)
+    {
         $redirect_url = session('cortex.fort.reauthentication.intended');
+        $session_name = session('cortex.fort.reauthentication.session_name');
 
         $guard = $this->getGuard();
-        $token = $request->input('token');
         $user = $request->user($guard);
+        $token = (int) $request->input('token');
 
-        if( $this->attemptTwoFactor($user, $token) ) {
+        if ($this->attemptTwoFactor($user, $token)) {
             $this->setSession($session_name);
 
             return intend([
-                'intended' => url($redirect_url)
-            ]);
-        } else {
-            return intend([
                 'intended' => url($redirect_url),
-                'withErrors' => ['token' => trans('cortex/fort::messages.verification.twofactor.invalid_token')],
             ]);
         }
+
+        return intend([
+            'intended' => url($redirect_url),
+            'withErrors' => ['token' => trans('cortex/fort::messages.verification.twofactor.invalid_token')],
+        ]);
     }
 
     /**
      * @param $session_name
      */
-    protected  function setSession($session_name) {
+    protected function setSession($session_name)
+    {
         session()->put($session_name, time());
-        session()->forget('cortex.fort.reauthentication.session_name');
         session()->forget('cortex.fort.reauthentication.intended');
-        session()->forget('rinvex.fort.twofactor.totp');
+        session()->forget('cortex.fort.reauthentication.session_name');
     }
-
 }

--- a/src/Http/Middleware/Reauthenticate.php
+++ b/src/Http/Middleware/Reauthenticate.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cortex\Fort\Http\Middleware;
+
+use Closure;
+
+class Reauthenticate
+{
+    /**
+     * Handle an incoming request.
+     *
+     * @param \Illuminate\Http\Request  $request
+     * @param \Closure                  $next
+     * @param string                    $type
+     * @param string|null               $session_name
+     * @param int|null                  $timeout
+     * @param bool                      $renew
+     *
+     * @return mixed
+     */
+    public function handle($request, Closure $next, $type='password', $session_name=null, $timeout=null, $renew=false)
+    {
+
+        $timeout = $timeout ?? config('cortex.fort.reauthentication.timeout');
+
+        if( is_null($session_name) || empty($session_name) ) {
+            $session_name = config('cortex.fort.reauthentication.prefix').$request->route()->getName();
+        } else {
+            $session_name = config('cortex.fort.reauthentication.prefix').$session_name;
+        }
+
+        if( is_null( session( $session_name ) ) || time() - session( $session_name ) >= $timeout ) {
+
+            session()->forget( $session_name );
+            session()->put('rinvex.fort.twofactor.totp', true);
+            session()->put(config('cortex.fort.reauthentication.prefix').'.intended', $request->url());
+            session()->put(config('cortex.fort.reauthentication.prefix').'.session_name', $session_name);
+
+            return view('cortex/fort::frontarea.common.reauthentication.'.$type);
+        }
+
+        if( $renew ) {
+            session()->put($session_name, time());
+        }
+
+        return $next($request);
+    }
+}

--- a/src/Http/Middleware/Reauthenticate.php
+++ b/src/Http/Middleware/Reauthenticate.php
@@ -26,17 +26,17 @@ class Reauthenticate
         $timeout = $timeout ?? config('cortex.fort.reauthentication.timeout');
 
         if( is_null($session_name) || empty($session_name) ) {
-            $session_name = config('cortex.fort.reauthentication.prefix').$request->route()->getName();
+            $session_name = 'cortex.fort.reauthentication.'.$request->route()->getName();
         } else {
-            $session_name = config('cortex.fort.reauthentication.prefix').$session_name;
+            $session_name = 'cortex.fort.reauthentication.'.$session_name;
         }
 
         if( is_null( session( $session_name ) ) || time() - session( $session_name ) >= $timeout ) {
 
             session()->forget( $session_name );
             session()->put('rinvex.fort.twofactor.totp', true);
-            session()->put(config('cortex.fort.reauthentication.prefix').'.intended', $request->url());
-            session()->put(config('cortex.fort.reauthentication.prefix').'.session_name', $session_name);
+            session()->put('cortex.fort.reauthentication.intended', $request->url());
+            session()->put('cortex.fort.reauthentication.session_name', $session_name);
 
             return view('cortex/fort::frontarea.common.reauthentication.'.$type);
         }

--- a/src/Http/Middleware/Reauthenticate.php
+++ b/src/Http/Middleware/Reauthenticate.php
@@ -11,39 +11,28 @@ class Reauthenticate
     /**
      * Handle an incoming request.
      *
-     * @param \Illuminate\Http\Request  $request
-     * @param \Closure                  $next
-     * @param string                    $type
-     * @param string|null               $session_name
-     * @param int|null                  $timeout
-     * @param bool                      $renew
+     * @param \Illuminate\Http\Request $request
+     * @param \Closure                 $next
+     * @param string                   $type
+     * @param int                      $timeout
+     * @param bool                     $renew
      *
      * @return mixed
      */
-    public function handle($request, Closure $next, $type='password', $session_name=null, $timeout=null, $renew=false)
+    public function handle($request, Closure $next, $type = 'password', $timeout = null, $renew = false)
     {
-
         $timeout = $timeout ?? config('cortex.fort.reauthentication.timeout');
-
-        if( is_null($session_name) || empty($session_name) ) {
-            $session_name = 'cortex.fort.reauthentication.'.$request->route()->getName();
-        } else {
-            $session_name = 'cortex.fort.reauthentication.'.$session_name;
-        }
-
-        if( is_null( session( $session_name ) ) || time() - session( $session_name ) >= $timeout ) {
-
-            session()->forget( $session_name );
-            session()->put('rinvex.fort.twofactor.totp', true);
+        $session_name = 'cortex.fort.reauthentication.'.$request->route()->getName();
+       
+        if(is_null(session($session_name)) || time() - session($session_name) >= $timeout) {
+            session()->forget($session_name);
             session()->put('cortex.fort.reauthentication.intended', $request->url());
             session()->put('cortex.fort.reauthentication.session_name', $session_name);
 
             return view('cortex/fort::frontarea.common.reauthentication.'.$type);
         }
 
-        if( $renew ) {
-            session()->put($session_name, time());
-        }
+        ! $renew || session()->put($session_name, time());
 
         return $next($request);
     }

--- a/src/Http/Middleware/Reauthenticate.php
+++ b/src/Http/Middleware/Reauthenticate.php
@@ -14,25 +14,26 @@ class Reauthenticate
      * @param \Illuminate\Http\Request $request
      * @param \Closure                 $next
      * @param string                   $type
+     * @param string                   $sessionName
      * @param int                      $timeout
      * @param bool                     $renew
      *
      * @return mixed
      */
-    public function handle($request, Closure $next, $type = 'password', $timeout = null, $renew = false)
+    public function handle($request, Closure $next, string $type = 'password', string $sessionName = null, int $timeout = null, bool $renew = false)
     {
         $timeout = $timeout ?? config('cortex.fort.reauthentication.timeout');
-        $session_name = 'cortex.fort.reauthentication.'.$request->route()->getName();
+        $sessionName = $sessionName ? 'cortex.fort.reauthentication.'.$sessionName : 'cortex.fort.reauthentication.'.$request->route()->getName();
        
-        if(is_null(session($session_name)) || time() - session($session_name) >= $timeout) {
-            session()->forget($session_name);
+        if(is_null(session($sessionName)) || time() - session($sessionName) >= $timeout) {
+            session()->forget($sessionName);
             session()->put('cortex.fort.reauthentication.intended', $request->url());
-            session()->put('cortex.fort.reauthentication.session_name', $session_name);
+            session()->put('cortex.fort.reauthentication.session_name', $sessionName);
 
             return view('cortex/fort::frontarea.common.reauthentication.'.$type);
         }
 
-        ! $renew || session()->put($session_name, time());
+        ! $renew || session()->put($sessionName, time());
 
         return $next($request);
     }

--- a/src/Providers/FortServiceProvider.php
+++ b/src/Providers/FortServiceProvider.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Cortex\Fort\Providers;
 
+use Cortex\Fort\Http\Middleware\Reauthenticate;
 use Illuminate\Http\Request;
 use Rinvex\Fort\Models\Role;
 use Rinvex\Fort\Models\User;
@@ -96,6 +97,9 @@ class FortServiceProvider extends ServiceProvider
 
         // Register attributes entities
         app('rinvex.attributes.entities')->push('user');
+
+        //Register new middleware
+        $router->aliasMiddleware('reauthenticate', Reauthenticate::class);
 
         // Register menus
         $this->registerMenus();

--- a/src/Traits/TwoFactorAuthenticatesUsers.php
+++ b/src/Traits/TwoFactorAuthenticatesUsers.php
@@ -13,11 +13,11 @@ trait TwoFactorAuthenticatesUsers
      * Verify TwoFactor authentication.
      *
      * @param \Rinvex\Fort\Contracts\AuthenticatableTwoFactorContract $user
-     * @param int                                                     $token
+     * @param string                                                  $token
      *
      * @return bool
      */
-    protected function attemptTwoFactor(AuthenticatableTwoFactorContract $user, int $token): bool
+    protected function attemptTwoFactor(AuthenticatableTwoFactorContract $user, string $token): bool
     {
         return $this->isValidTwoFactorTotp($user, $token) || $this->isValidTwoFactorBackup($user, $token) || $this->isValidTwoFactorPhone($user, $token);
     }
@@ -26,11 +26,11 @@ trait TwoFactorAuthenticatesUsers
      * Invalidate given backup code for the given user.
      *
      * @param \Rinvex\Fort\Contracts\AuthenticatableTwoFactorContract $user
-     * @param int                                                     $token
+     * @param string                                                  $token
      *
      * @return void
      */
-    protected function invalidateTwoFactorBackup(AuthenticatableTwoFactorContract $user, int $token): void
+    protected function invalidateTwoFactorBackup(AuthenticatableTwoFactorContract $user, string $token): void
     {
         $settings = $user->getTwoFactor();
         $backup = array_get($settings, 'totp.backup');
@@ -47,11 +47,11 @@ trait TwoFactorAuthenticatesUsers
      * Determine if the given token is a valid TwoFactor Phone token.
      *
      * @param \Rinvex\Fort\Contracts\AuthenticatableTwoFactorContract $user
-     * @param int                                                     $token
+     * @param string                                                  $token
      *
      * @return bool
      */
-    protected function isValidTwoFactorPhone(AuthenticatableTwoFactorContract $user, int $token): bool
+    protected function isValidTwoFactorPhone(AuthenticatableTwoFactorContract $user, string $token): bool
     {
         $settings = $user->getTwoFactor();
         $authyId = array_get($settings, 'phone.authy_id');
@@ -63,11 +63,11 @@ trait TwoFactorAuthenticatesUsers
      * Determine if the given token is a valid TwoFactor Backup code.
      *
      * @param \Rinvex\Fort\Contracts\AuthenticatableTwoFactorContract $user
-     * @param int                                                     $token
+     * @param string                                                  $token
      *
      * @return bool
      */
-    protected function isValidTwoFactorBackup(AuthenticatableTwoFactorContract $user, int $token): bool
+    protected function isValidTwoFactorBackup(AuthenticatableTwoFactorContract $user, string $token): bool
     {
         $backup = array_get($user->getTwoFactor(), 'totp.backup', []);
         $result = mb_strlen($token) === 10 && in_array($token, $backup);
@@ -80,11 +80,11 @@ trait TwoFactorAuthenticatesUsers
      * Determine if the given token is a valid TwoFactor TOTP token.
      *
      * @param \Rinvex\Fort\Contracts\AuthenticatableTwoFactorContract $user
-     * @param int                                                     $token
+     * @param string                                                  $token
      *
      * @return bool
      */
-    protected function isValidTwoFactorTotp(AuthenticatableTwoFactorContract $user, int $token): bool
+    protected function isValidTwoFactorTotp(AuthenticatableTwoFactorContract $user, string $token): bool
     {
         $totpProvider = app(Google2FA::class);
         $secret = array_get($user->getTwoFactor(), 'totp.secret');

--- a/src/Traits/TwoFactorAuthenticatesUsers.php
+++ b/src/Traits/TwoFactorAuthenticatesUsers.php
@@ -13,11 +13,11 @@ trait TwoFactorAuthenticatesUsers
      * Verify TwoFactor authentication.
      *
      * @param \Rinvex\Fort\Contracts\AuthenticatableTwoFactorContract $user
-     * @param string                                                  $token
+     * @param int                                                     $token
      *
      * @return bool
      */
-    protected function attemptTwoFactor(AuthenticatableTwoFactorContract $user, string $token): bool
+    protected function attemptTwoFactor(AuthenticatableTwoFactorContract $user, int $token): bool
     {
         return $this->isValidTwoFactorTotp($user, $token) || $this->isValidTwoFactorBackup($user, $token) || $this->isValidTwoFactorPhone($user, $token);
     }
@@ -26,11 +26,11 @@ trait TwoFactorAuthenticatesUsers
      * Invalidate given backup code for the given user.
      *
      * @param \Rinvex\Fort\Contracts\AuthenticatableTwoFactorContract $user
-     * @param string                                                  $token
+     * @param int                                                     $token
      *
      * @return void
      */
-    protected function invalidateTwoFactorBackup(AuthenticatableTwoFactorContract $user, string $token): void
+    protected function invalidateTwoFactorBackup(AuthenticatableTwoFactorContract $user, int $token): void
     {
         $settings = $user->getTwoFactor();
         $backup = array_get($settings, 'totp.backup');
@@ -47,11 +47,11 @@ trait TwoFactorAuthenticatesUsers
      * Determine if the given token is a valid TwoFactor Phone token.
      *
      * @param \Rinvex\Fort\Contracts\AuthenticatableTwoFactorContract $user
-     * @param string                                                  $token
+     * @param int                                                     $token
      *
      * @return bool
      */
-    protected function isValidTwoFactorPhone(AuthenticatableTwoFactorContract $user, string $token): bool
+    protected function isValidTwoFactorPhone(AuthenticatableTwoFactorContract $user, int $token): bool
     {
         $settings = $user->getTwoFactor();
         $authyId = array_get($settings, 'phone.authy_id');
@@ -63,11 +63,11 @@ trait TwoFactorAuthenticatesUsers
      * Determine if the given token is a valid TwoFactor Backup code.
      *
      * @param \Rinvex\Fort\Contracts\AuthenticatableTwoFactorContract $user
-     * @param string                                                  $token
+     * @param int                                                     $token
      *
      * @return bool
      */
-    protected function isValidTwoFactorBackup(AuthenticatableTwoFactorContract $user, string $token): bool
+    protected function isValidTwoFactorBackup(AuthenticatableTwoFactorContract $user, int $token): bool
     {
         $backup = array_get($user->getTwoFactor(), 'totp.backup', []);
         $result = mb_strlen($token) === 10 && in_array($token, $backup);
@@ -80,11 +80,11 @@ trait TwoFactorAuthenticatesUsers
      * Determine if the given token is a valid TwoFactor TOTP token.
      *
      * @param \Rinvex\Fort\Contracts\AuthenticatableTwoFactorContract $user
-     * @param string                                                  $token
+     * @param int                                                     $token
      *
      * @return bool
      */
-    protected function isValidTwoFactorTotp(AuthenticatableTwoFactorContract $user, string $token): bool
+    protected function isValidTwoFactorTotp(AuthenticatableTwoFactorContract $user, int $token): bool
     {
         $totpProvider = app(Google2FA::class);
         $secret = array_get($user->getTwoFactor(), 'totp.secret');


### PR DESCRIPTION
Implementation for https://github.com/rinvex/fort/issues/84

@Omranic - First running version :)

Already tested:
* Reauth via Password
* Reauth via TOTP 

I'm unable to test the phone verification - Maybe you have some tipps how to test it, then i can implement also the phone verification.

The implementation is based on https://gist.github.com/noxify/90ffac363138e43bc330b74df6c9cfbc .

But i changed the handling, inspired by https://github.com/mpociot/reauthenticate.
Now the user will not redirect to a new page. Instead they see the target address in the browser.

I think it's more secure.

### Testing

Add / Update the existing middleware:

```
Route::namespace('Backend')->name('rinvex.fort.backend.')->prefix('backend')->middleware(['web', 'reauthenticate:password,3600,true', 'can:access-dashboard'])->group(function () {
    //...
})
```

or

```
Route::get('/')->name('dashboard.home')->uses('DashboardController@home')->middleware(['reauthenticate:password,,3600,true']);
```


## Middleware Parameters

1. Type: password (default) / twofactor
2. Session Timeout - null (default is 3600 via config) / own value
3. Renew Session - false (default) / true

## Todos
* The views are duplicates from the login view. I think we have to change them a bit.
* Also I'm not sure if the area (frontarea) is the correct one

Feel free to edit this PR or let me know if I should change something :)